### PR TITLE
refactor: update vscode generator and tailwind plugin

### DIFF
--- a/src/generators/github-actions.generator.ts
+++ b/src/generators/github-actions.generator.ts
@@ -3,7 +3,7 @@ import type { GithubWorkflow, Option } from '../types/index.js'
 import fs from 'node:fs/promises'
 
 import { multiselect, outro } from '@clack/prompts'
-import pc from 'picocolors'
+import colors from 'picocolors'
 
 import { addGithubWorkflow, handleCancelPrompt } from '../utils/index.js'
 import { GITHUB_WORKFLOWS } from '../constants/index.js'
@@ -27,8 +27,8 @@ export const githubActions = async () => {
   }
 
   outro(
-    pc.bgCyan(
-      pc.black(
+    colors.bgCyan(
+      colors.black(
         ` ${new Intl.ListFormat('en', { style: 'long', type: 'conjunction' }).format(
           ghActions,
         )} workflow has been added `,

--- a/src/generators/husky.generator.ts
+++ b/src/generators/husky.generator.ts
@@ -59,7 +59,7 @@ export const husky = async () => {
 
   await execCmd('npm pkg set scripts.commitlint="commitlint --edit"')
 
-  const cmd = 'npx husky add .husky/commit-msg "pkg run commitlint \\${1}"'
+  const cmd = "npx husky add .husky/commit-msg 'pkg run commitlint ${1}'"
 
   await execCmd(cmd.replace('pkg', packageManager))
 

--- a/src/generators/next-ts.generator.ts
+++ b/src/generators/next-ts.generator.ts
@@ -1,7 +1,7 @@
 import type { Option, PackageManger } from '../types/index.js'
 
 import { confirm, select, outro } from '@clack/prompts'
-import pc from 'picocolors'
+import colors from 'picocolors'
 
 import {
   prettierIgnore,
@@ -51,8 +51,8 @@ export const nextTs = async () => {
   }
 
   if (tailwind) {
-    eslintNext.extends.push('plugin:tailwindcss/recommended')
-    nextDependencies.push('eslint-plugin-tailwindcss')
+    prettierrc.plugins = ['prettier-plugin-tailwindcss']
+    nextDependencies.push('prettier-plugin-tailwindcss')
   }
 
   await addFile('.editorconfig', editorconfig)
@@ -64,8 +64,8 @@ export const nextTs = async () => {
   await installDependencies({ dependencies: nextDependencies, packageManager, saveDev: true })
 
   outro(
-    pc.bgCyan(
-      pc.black(
+    colors.bgCyan(
+      colors.black(
         ' Added .editorconfig, .eslintrc.json, .eslintingore, .prettierrc, .prettierignore ',
       ),
     ),

--- a/src/generators/node-ts.generator.ts
+++ b/src/generators/node-ts.generator.ts
@@ -1,7 +1,7 @@
 import type { Option, PackageManger } from '../types/index.js'
 
 import { confirm, select, outro } from '@clack/prompts'
-import pc from 'picocolors'
+import colors from 'picocolors'
 
 import { PACKAGE_MANAGER } from '../constants/index.js'
 import {
@@ -52,8 +52,8 @@ export const nodeTs = async () => {
   await installDependencies({ dependencies: nodeDependencies, packageManager, saveDev: true })
 
   outro(
-    pc.bgCyan(
-      pc.black(
+    colors.bgCyan(
+      colors.black(
         ' Added .editorconfig, .eslintrc.json, .eslintingore, .prettierrc, .prettierignore ',
       ),
     ),

--- a/src/generators/react-ts.generator.ts
+++ b/src/generators/react-ts.generator.ts
@@ -1,7 +1,7 @@
 import type { Option, PackageManger } from '../types/index.js'
 
 import { confirm, select, outro } from '@clack/prompts'
-import pc from 'picocolors'
+import colors from 'picocolors'
 
 import { PACKAGE_MANAGER } from '../constants/index.js'
 import {
@@ -51,8 +51,8 @@ export const reactTs = async () => {
   }
 
   if (tailwind) {
-    eslintReact.extends.push('plugin:tailwindcss/recommended')
-    reactDependencies.push('eslint-plugin-tailwindcss')
+    prettierrc.plugins = ['prettier-plugin-tailwindcss']
+    reactDependencies.push('prettier-plugin-tailwindcss')
   }
 
   await addFile('.editorconfig', editorconfig)
@@ -64,8 +64,8 @@ export const reactTs = async () => {
   await installDependencies({ dependencies: reactDependencies, packageManager, saveDev: true })
 
   outro(
-    pc.bgCyan(
-      pc.black(
+    colors.bgCyan(
+      colors.black(
         ' Added .editorconfig, .eslintrc.json, .eslintingore, .prettierrc, .prettierignore ',
       ),
     ),

--- a/src/generators/vscode.generator.ts
+++ b/src/generators/vscode.generator.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs/promises'
 
-import pc from 'picocolors'
+import colors from 'picocolors'
 import { confirm, outro } from '@clack/prompts'
 
 import { extensions, settings } from '../templates/index.js'
@@ -24,8 +24,8 @@ export const vscode = async () => {
   await addFile('.vscode/extensions.json', extensions)
 
   outro(
-    pc.bgCyan(
-      pc.black(' settings.json and extensions.json have been added to the .vscode folder '),
+    colors.bgCyan(
+      colors.black(' settings.json and extensions.json have been added to the .vscode folder '),
     ),
   )
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,13 +3,13 @@
 import type { Generator, Option } from './types/index.js'
 
 import { intro, select } from '@clack/prompts'
-import pc from 'picocolors'
+import colors from 'picocolors'
 
 import { handleCancelPrompt } from './utils/index.js'
 import { GENERATORS_OPTIONS } from './constants/generator.constant.js'
 import { RUN_GENERATOR } from './generators/index.js'
 
-intro(pc.bgCyan(pc.black(' Welcome to Santux Generator! ')))
+intro(colors.bgCyan(colors.black(' Welcome to Santux Generator! ')))
 
 const option = handleCancelPrompt(
   await select<Option<Generator>[], Generator>({

--- a/src/templates/prettier.template.ts
+++ b/src/templates/prettier.template.ts
@@ -4,7 +4,7 @@ package-lock.json
 pnpm-lock.yaml
 yarn.lock`
 
-export const prettierrc = {
+export const prettierrc: Record<string, string | number | boolean | string[]> = {
   arrowParens: 'always',
   bracketSameLine: false,
   bracketSpacing: true,

--- a/src/templates/vscode.template.ts
+++ b/src/templates/vscode.template.ts
@@ -10,6 +10,6 @@ export const settings = {
   'editor.defaultFormatter': 'esbenp.prettier-vscode',
   'editor.formatOnSave': true,
   'editor.codeActionsOnSave': {
-    'source.fixAll.eslint': true,
+    'source.fixAll': 'explicit',
   },
 }

--- a/src/utils/install-dependencies.util.ts
+++ b/src/utils/install-dependencies.util.ts
@@ -1,7 +1,7 @@
 import type { PackageManger } from '../types/index.js'
 
 import { spinner as createSpinner } from '@clack/prompts'
-import pc from 'picocolors'
+import colors from 'picocolors'
 
 import { execCmd } from './index.js'
 
@@ -28,8 +28,8 @@ export const installDependencies = async ({
   )
 
   spinner.stop(
-    `${pc.bgCyan(pc.black(' Dependencies installed: '))}
-${pc.gray('│')}
-${dependencies.map((dep) => `${pc.gray('│ ')} ${dep}`).join('\n')}`,
+    `${colors.bgCyan(colors.black(' Dependencies installed: '))}
+${colors.gray('│')}
+${dependencies.map((dep) => `${colors.gray('│ ')} ${dep}`).join('\n')}`,
   )
 }


### PR DESCRIPTION
All pc imports (picocolors) has been renamed to colors. The ESLint tailwindcss plugin has been replaced by the prettier plugin. The ESLint VSCode setting has been updated with the `explicit` value.